### PR TITLE
A collector-reporter strategy with up to 3 count reports

### DIFF
--- a/strategy/my_strategy.go
+++ b/strategy/my_strategy.go
@@ -1,6 +1,8 @@
 package strategy
 
 import "github.com/tarao/prisoners-switch/rule"
+	
+const kCount = 2000
 
 // MyNewStrategy returns a new strategy
 func MyNewStrategy() rule.Strategy {
@@ -16,9 +18,36 @@ func (s *myStrategy) NewPrisoner(number int, shout chan rule.Shout) rule.Prisone
 
 type prisoner struct {
 	shout chan rule.Shout
+	cnt int
+	done bool
+	initA bool
+	initB bool
 }
 
 func (p *prisoner) Enter(room rule.Room) {
-	// shout triumph when you think it's ready
+	if p.done {
+		return
+	}
+	if p.cnt == 0 {
+		p.initA = room.TakeSwitchA().State()
+		p.initB = room.TakeSwitchB().State()
+	}
+	p.cnt++
+	if p.cnt < kCount {
+		return
+	}
+	if p.initA == room.TakeSwitchA().State() && p.initB == room.TakeSwitchB().State() {
+		// probably the first
+		room.TakeSwitchA().Toggle()
+		p.done = true
+		return
+	}
+	if p.initB == room.TakeSwitchB().State() {
+		// probably the second
+		room.TakeSwitchB().Toggle()
+		p.done = true
+		return
+	}
+	// probably the third
 	p.shout <- rule.Triumph
 }

--- a/strategy/my_strategy.go
+++ b/strategy/my_strategy.go
@@ -28,9 +28,9 @@ type prisoner struct {
 	remaining int
 
 	// worker fields.
-	initialState int
+	initialState         int
 	initialStateModified bool
-	incremented bool
+	incremented          bool
 }
 
 func (p *prisoner) Enter(room rule.Room) {
@@ -54,8 +54,7 @@ func (p *prisoner) workerEnter(room rule.Room) {
 	p.initialStateModified = true
 
 	if !p.incremented && c < 3 {
-		c++
-		setCounter(room, c)
+		setCounter(room, c+1)
 		p.incremented = true
 	}
 }
@@ -94,10 +93,10 @@ func getCounter(room rule.Room) int {
 	return c
 }
 
-func setCounter(room rule.Room, n int) {
+func setCounter(room rule.Room, c int) {
 	sa, sb := room.TakeSwitchA(), room.TakeSwitchB()
-	a := (n % 2) != 0
-	b := (n / 2) != 0
+	a := (c % 2) != 0
+	b := (c / 2) != 0
 	if sa.State() != a {
 		sa.Toggle()
 	}

--- a/strategy/my_strategy.go
+++ b/strategy/my_strategy.go
@@ -12,14 +12,95 @@ type myStrategy struct {
 
 // Each prisoner receives unique number between 0 and rule.TotalPrisoners -1. Order is not guaranteed.
 func (s *myStrategy) NewPrisoner(number int, shout chan rule.Shout) rule.Prisoner {
-	return &prisoner{shout: shout}
+	return &prisoner{
+		shout:       shout,
+		isCollector: number == 0,
+		remaining:   rule.TotalPrisoners - 1, // number of workers not reporting yet
+	}
 }
 
 type prisoner struct {
-	shout chan rule.Shout
+	shout       chan rule.Shout
+	isCollector bool
+	initialized bool
+
+	// collector fields.
+	remaining int
+
+	// worker fields.
+	initialState         int
+	initialStateModified bool
+	incremented          bool
 }
 
 func (p *prisoner) Enter(room rule.Room) {
-	// shout triumph when you think it's ready
-	p.shout <- rule.Triumph
+	if p.isCollector {
+		p.collectorEnter(room)
+	} else {
+		p.workerEnter(room)
+	}
+}
+
+func (p *prisoner) workerEnter(room rule.Room) {
+	c := getCounter(room)
+	if !p.initialized {
+		p.initialState = c
+		p.initialized = true
+		return
+	}
+	if !p.initialStateModified && p.initialState == c {
+		return
+	}
+	p.initialStateModified = true
+
+	if !p.incremented && c < 3 {
+		setCounter(room, c+1)
+		p.incremented = true
+	}
+}
+
+func (p *prisoner) collectorEnter(room rule.Room) {
+	c := getCounter(room)
+	defer func() {
+		if c == 0 {
+			// change switch state to notify workers that the collector is ready.
+			setCounter(room, 1)
+			p.remaining++
+		} else {
+			setCounter(room, 0)
+		}
+	}()
+
+	if !p.initialized {
+		p.initialized = true
+		return
+	}
+	p.remaining -= c
+	if p.remaining == 0 {
+		p.shout <- rule.Triumph
+	}
+}
+
+func getCounter(room rule.Room) int {
+	sa, sb := room.TakeSwitchA(), room.TakeSwitchB()
+	c := 0
+	if sa.State() {
+		c += 1
+	}
+	if sb.State() {
+		c += 2
+	}
+	return c
+}
+
+func setCounter(room rule.Room, c int) {
+	sa, sb := room.TakeSwitchA(), room.TakeSwitchB()
+	a := (c % 2) != 0
+	b := (c / 2) != 0
+	if sa.State() != a {
+		sa.Toggle()
+	}
+	if sb.State() != b {
+		sb.Toggle()
+	}
 }

--- a/strategy/my_strategy.go
+++ b/strategy/my_strategy.go
@@ -27,7 +27,8 @@ type prisoner struct {
 	remaining int
 
 	// worker fields.
-	lastSeen    int
+	initialState int
+	initialStateModified bool
 	incremented bool
 }
 
@@ -42,13 +43,14 @@ func (p *prisoner) Enter(room rule.Room) {
 func (p *prisoner) workerEnter(room rule.Room) {
 	c := getCounter(room)
 	if !p.initialized {
-		p.lastSeen = c
+		p.initialState = c
 		p.initialized = true
 		return
 	}
-	if p.lastSeen == c {
+	if !p.initialStateModified && p.initialState == c {
 		return
 	}
+	p.initialStateModified = true
 
 	if !p.incremented && c < 3 {
 		c++

--- a/strategy/my_strategy.go
+++ b/strategy/my_strategy.go
@@ -95,8 +95,8 @@ func getCounter(room rule.Room) int {
 
 func setCounter(room rule.Room, c int) {
 	sa, sb := room.TakeSwitchA(), room.TakeSwitchB()
-	a := (c % 2) != 0
-	b := (c / 2) != 0
+	a := (c & 1) != 0
+	b := (c & 2) != 0
 	if sa.State() != a {
 		sa.Toggle()
 	}

--- a/strategy/my_strategy.go
+++ b/strategy/my_strategy.go
@@ -15,7 +15,7 @@ func (s *myStrategy) NewPrisoner(number int, shout chan rule.Shout) rule.Prisone
 	return &prisoner{
 		shout:       shout,
 		isCollector: number == 0,
-		remaining:   rule.TotalPrisoners - 1, // number of workers not reporting yet
+		remaining:   rule.TotalPrisoners - 1, // number of reporters not reporting yet
 	}
 }
 
@@ -27,21 +27,21 @@ type prisoner struct {
 	// collector fields.
 	remaining int
 
-	// worker fields.
+	// reporter fields.
 	initialState         int
 	initialStateModified bool
-	incremented          bool
+	reported          bool
 }
 
 func (p *prisoner) Enter(room rule.Room) {
 	if p.isCollector {
 		p.collectorEnter(room)
 	} else {
-		p.workerEnter(room)
+		p.reporterEnter(room)
 	}
 }
 
-func (p *prisoner) workerEnter(room rule.Room) {
+func (p *prisoner) reporterEnter(room rule.Room) {
 	c := getCounter(room)
 	if !p.initialized {
 		p.initialState = c
@@ -53,9 +53,9 @@ func (p *prisoner) workerEnter(room rule.Room) {
 	}
 	p.initialStateModified = true
 
-	if !p.incremented && c < 3 {
+	if !p.reported && c < 3 {
 		setCounter(room, c+1)
-		p.incremented = true
+		p.reported = true
 	}
 }
 
@@ -63,7 +63,7 @@ func (p *prisoner) collectorEnter(room rule.Room) {
 	c := getCounter(room)
 	defer func() {
 		if c == 0 {
-			// change switch state to notify workers that the collector is ready.
+			// change switch state to notify reporters that the collector is ready.
 			setCounter(room, 1)
 			p.remaining++
 		} else {

--- a/strategy/my_strategy.go
+++ b/strategy/my_strategy.go
@@ -1,8 +1,6 @@
 package strategy
 
 import "github.com/tarao/prisoners-switch/rule"
-	
-const kCount = 2000
 
 // MyNewStrategy returns a new strategy
 func MyNewStrategy() rule.Strategy {
@@ -13,41 +11,94 @@ type myStrategy struct {
 }
 
 func (s *myStrategy) NewPrisoner(number int, shout chan rule.Shout) rule.Prisoner {
-	return &prisoner{shout: shout}
+	return &prisoner{
+		shout:       shout,
+		isCollector: number == 0,
+		remaining:   rule.TotalPrisoners - 1, // number of workers not reporting yet
+	}
 }
 
 type prisoner struct {
-	shout chan rule.Shout
-	cnt int
-	done bool
-	initA bool
-	initB bool
+	shout       chan rule.Shout
+	isCollector bool
+	initialized bool
+
+	// collector fields.
+	remaining   int
+
+	// worker fields.
+	lastSeen    int
+	incremented bool
 }
 
 func (p *prisoner) Enter(room rule.Room) {
-	if p.done {
+	if p.isCollector {
+		p.collectorEnter(room)
+	} else {
+		p.workerEnter(room)
+	}
+}
+
+func (p *prisoner) workerEnter(room rule.Room) {
+	c := getCounter(room)
+	if !p.initialized {
+		p.lastSeen = c
+		p.initialized = true
 		return
 	}
-	if p.cnt == 0 {
-		p.initA = room.TakeSwitchA().State()
-		p.initB = room.TakeSwitchB().State()
-	}
-	p.cnt++
-	if p.cnt < kCount {
+	if p.lastSeen == c {
 		return
 	}
-	if p.initA == room.TakeSwitchA().State() && p.initB == room.TakeSwitchB().State() {
-		// probably the first
-		room.TakeSwitchA().Toggle()
-		p.done = true
+
+	if !p.incremented && c < 2 {
+		c++
+		setCounter(room, c)
+		p.incremented = true
+	}
+}
+
+func (p *prisoner) collectorEnter(room rule.Room) {
+	c := getCounter(room)
+	defer func(){
+		if c == 0 {
+			// change switch state to notify workers that the collector is ready.
+			setCounter(room, 1)
+			p.remaining++
+		} else {
+			setCounter(room, 0)
+		}
+	}()
+
+	if !p.initialized {
+		p.initialized = true
 		return
 	}
-	if p.initB == room.TakeSwitchB().State() {
-		// probably the second
-		room.TakeSwitchB().Toggle()
-		p.done = true
-		return
+	p.remaining -= c
+	if p.remaining == 0 {
+		p.shout <- rule.Triumph
 	}
-	// probably the third
-	p.shout <- rule.Triumph
+}
+
+func getCounter(room rule.Room) int {
+	sa, sb := room.TakeSwitchA(), room.TakeSwitchB()
+	c := 0
+	if sa.State() {
+		c += 1
+	}
+	if sb.State() {
+		c += 2
+	}
+	return c
+}
+
+func setCounter(room rule.Room, n int) {
+	sa, sb := room.TakeSwitchA(), room.TakeSwitchB()
+	a := (n % 2) != 0
+	b := (n / 2) != 0
+	if sa.State() != a {
+		sa.Toggle()
+	}
+	if sb.State() != b {
+		sb.Toggle()
+	}
 }

--- a/strategy/my_strategy.go
+++ b/strategy/my_strategy.go
@@ -30,7 +30,7 @@ type prisoner struct {
 	// reporter fields.
 	initialState         int
 	initialStateModified bool
-	reported          bool
+	reported             bool
 }
 
 func (p *prisoner) Enter(room rule.Room) {


### PR DESCRIPTION
An improvement to: https://github.com/tarao/prisoners-switch/pull/11

This strategy effectively uses N switches as an N-bit counter.
Up to (2^N - 1) workers can increment the counter in each collection cycle.
It's N=2 in our problem, but this algorithm can be easily generalized to arbitrary number of switches (including N=1 as I submitted separately).